### PR TITLE
fix: swap buffers & smear.nvim

### DIFF
--- a/lua/plugins/folke-plugins.lua
+++ b/lua/plugins/folke-plugins.lua
@@ -348,29 +348,26 @@ return {
         -- swap buffers
         {
           "<leader>bs",
-          -- Function to swap buffers between two windows
           function()
-            -- Get the current window and buffer
             local current_win = vim.api.nvim_get_current_win()
             local current_buf = vim.api.nvim_win_get_buf(current_win)
-
-            -- Get the list of all windows
             local windows = vim.api.nvim_list_wins()
 
-            -- Find the other window
             for _, win in ipairs(windows) do
               if win ~= current_win then
-                -- Get the buffer in the other window
                 local other_buf = vim.api.nvim_win_get_buf(win)
 
-                -- Swap the buffers
-                vim.api.nvim_win_set_buf(current_win, other_buf)
-                vim.api.nvim_win_set_buf(win, current_buf)
-                return
+                -- Skip empty/scratch buffers
+                local buftype = vim.api.nvim_buf_get_option(other_buf, 'buftype')
+                if buftype == "" then  -- Normal file buffer
+                  vim.api.nvim_win_set_buf(current_win, other_buf)
+                  vim.api.nvim_win_set_buf(win, current_buf)
+                  return
+                end
               end
             end
 
-            print("No other window found to swap buffers with!")
+            print("No other window with a file buffer found to swap with!")
           end,
           desc = "Swap buffers"
         },

--- a/lua/plugins/styling.lua
+++ b/lua/plugins/styling.lua
@@ -193,12 +193,16 @@ return {
   -- smear.nvim
   {
     "sphamba/smear-cursor.nvim",
-    opts = {                         -- Deafult  Range
-      stiffness = 0.8,               -- 0.6      [0, 1]
-      trailing_stiffness = 0.3,      -- 0.4      [0, 1]
-      distance_stop_animating = 0.5, -- 0.1      > 0
-      -- stiffness_insert_mode = 0.6,          -- 0.4      [0, 1]
-      -- trailing_stiffness_insert_mode = 0.6, -- 0.4      [0, 1]
+    enabled = not vim.g.neovide,            -- disable when using neovide
+    opts = {                                -- Default  Range
+      cursor_color                   = "#209fb5",
+      stiffness                      = 0.8, -- 0.6      [0, 1]
+      trailing_stiffness             = 0.5, -- 0.4      [0, 1]
+      stiffness_insert_mode          = 0.7, -- 0.4      [0, 1]
+      trailing_stiffness_insert_mode = 0.6, -- 0.4      [0, 1]
+      damping                        = 0.5, -- 0.65     [0, 1]
+      damping_insert_mode            = 0.8, -- 0.7      [0, 1]
+      distance_stop_animating        = 0.5, -- 0.1      > 0
 
       -- Smear cursor when switching buffers or windows.
       smear_between_buffers = true,


### PR DESCRIPTION
- fix <space>bs swapping into an empty buffer. When only one buffer is open
- disable smear.nvim when using neovide